### PR TITLE
Added variant padding for existing variants and explicitly created a …

### DIFF
--- a/apps/react-native-doc/package-lock.json
+++ b/apps/react-native-doc/package-lock.json
@@ -47,11 +47,10 @@
 			}
 		},
 		".yalc/@sf-digital-ui/react-native": {
-			"version": "2.2.7",
+			"version": "2.2.6",
 			"license": "MIT",
 			"dependencies": {
-				"expo-checkbox": "^4.0.1",
-				"lucide-react-native": "^0.488.0"
+				"expo-checkbox": "^4.0.1"
 			},
 			"peerDependencies": {
 				"react": ">=16.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18471,7 +18471,7 @@
 		},
 		"packages/react-native": {
 			"name": "@sf-digital-ui/react-native",
-			"version": "2.2.7",
+			"version": "2.3.1",
 			"license": "MIT",
 			"dependencies": {
 				"expo-checkbox": "^4.0.1",

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @sf-digital-ui/react-native
 
+## 2.3.1
+
+### Patch Changes
+
+- Design System Button Link variant has its own styling now, removing padding as per the fireball reported
+
 ## 2.3.0
 
 ### Minor Changes

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @sf-digital-ui/react-native
 
+## 2.3.2
+
+### Patch Changes
+
+- fix the link variant width issue
+
 ## 2.3.1
 
 ### Patch Changes

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sf-digital-ui/react-native",
-	"version": "2.3.1",
+	"version": "2.3.2",
 	"main": "dist/index.js",
 	"module": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sf-digital-ui/react-native",
-	"version": "2.3.0",
+	"version": "2.3.1",
 	"main": "dist/index.js",
 	"module": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/react-native/src/components/Button/Root/index.tsx
+++ b/packages/react-native/src/components/Button/Root/index.tsx
@@ -99,6 +99,29 @@ const buttonStyles = createStylesheet<ButtonVariants>({
 			variants: {
 				size: 'sm',
 				iconButton: false,
+				variant: 'primary',
+			},
+			style: {
+				paddingHorizontal: 24,
+				paddingVertical: 8,
+			},
+		},
+		{
+			variants: {
+				size: 'sm',
+				iconButton: false,
+				variant: 'secondary',
+			},
+			style: {
+				paddingHorizontal: 24,
+				paddingVertical: 8,
+			},
+		},
+		{
+			variants: {
+				size: 'sm',
+				iconButton: false,
+				variant: 'tertiary',
 			},
 			style: {
 				paddingHorizontal: 24,
@@ -109,6 +132,29 @@ const buttonStyles = createStylesheet<ButtonVariants>({
 			variants: {
 				size: 'md',
 				iconButton: false,
+				variant: 'primary',
+			},
+			style: {
+				paddingHorizontal: 24,
+				paddingVertical: 10,
+			},
+		},
+		{
+			variants: {
+				size: 'md',
+				iconButton: false,
+				variant: 'secondary',
+			},
+			style: {
+				paddingHorizontal: 24,
+				paddingVertical: 10,
+			},
+		},
+		{
+			variants: {
+				size: 'md',
+				iconButton: false,
+				variant: 'tertiary',
 			},
 			style: {
 				paddingHorizontal: 24,
@@ -119,6 +165,29 @@ const buttonStyles = createStylesheet<ButtonVariants>({
 			variants: {
 				size: 'lg',
 				iconButton: false,
+				variant: 'primary',
+			},
+			style: {
+				paddingHorizontal: 32,
+				paddingVertical: 10,
+			},
+		},
+		{
+			variants: {
+				size: 'lg',
+				iconButton: false,
+				variant: 'secondary',
+			},
+			style: {
+				paddingHorizontal: 32,
+				paddingVertical: 10,
+			},
+		},
+		{
+			variants: {
+				size: 'lg',
+				iconButton: false,
+				variant: 'tertiary',
 			},
 			style: {
 				paddingHorizontal: 32,
@@ -150,6 +219,15 @@ const buttonStyles = createStylesheet<ButtonVariants>({
 			},
 			style: {
 				padding: 12,
+			},
+		},
+		{
+			variants: {
+				variant: 'link',
+			},
+			style: {
+				padding: 0,
+				backgroundColor: 'transparent',
 			},
 		},
 		{

--- a/packages/react-native/src/components/Button/Root/index.tsx
+++ b/packages/react-native/src/components/Button/Root/index.tsx
@@ -54,7 +54,7 @@ export const useButtonContext = () => {
 const buttonStyles = createStylesheet<ButtonVariants>({
 	base: {
 		alignItems: 'center',
-		flexDirection: 'row',
+
 		gap: 4,
 		borderRadius: 6,
 	},
@@ -65,12 +65,17 @@ const buttonStyles = createStylesheet<ButtonVariants>({
 			lg: {},
 		},
 		variant: {
-			primary: {},
+			primary: {
+				flexDirection: 'row',
+			},
 			secondary: {
+				flexDirection: 'row',
 				backgroundColor: 'white',
 				borderWidth: 1,
 			},
-			tertiary: {},
+			tertiary: {
+				flexDirection: 'row',
+			},
 			link: {},
 		},
 		color: {
@@ -219,15 +224,6 @@ const buttonStyles = createStylesheet<ButtonVariants>({
 			},
 			style: {
 				padding: 12,
-			},
-		},
-		{
-			variants: {
-				variant: 'link',
-			},
-			style: {
-				padding: 0,
-				backgroundColor: 'transparent',
 			},
 		},
 		{


### PR DESCRIPTION
…no padding variant for the link button variant

# Design System

Before making this Pull Request "Ready for review", please make the following checks first...

## What type of PR is this?

- [ ] 🍕 Feature 
- [X] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [X] 🤖 Chore
- [ ] 🔁 CI

## Related tickets and documents

See the notions for further information: [https://www.notion.so/Button-Link-variant-1dfe199bafd280bc95dae91b270cec12?pvs=4](url)

## Description

This bug fix makes sure that the link variant of our button component has no additional padding when you use it. I did this by creating new objects for the existing variants and explicitly moving the link variant to its own object. The newly created object defines padding as 0 explicitly which should address the reported bug.

## Usage (optional)

## Checklist

### Have you written documentation?

- [ ] 📜 README.md
- [ ] 📕 Storybook
- [X] 📲 React Native Documentation
- [ ] 🙅‍♂️ No documentation needed

## Desktop Screenshots (optional)


